### PR TITLE
:pushpin: Drop support for Python 3.8; add support for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cookiecutter-python-cli-app
 
-[![Supported Python Versions](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11%20|%203.12-blue)](https://github.com/sgraaf/cookiecutter-python-cli-app)
+[![Supported Python Versions](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13-blue)](https://github.com/sgraaf/cookiecutter-python-cli-app)
 [![Nox](https://img.shields.io/badge/%F0%9F%A6%8A-Nox-D85E00.svg)](https://github.com/wntrblm/nox)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/format.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
@@ -32,4 +32,4 @@ cookiecutter gh:sgraaf/cookiecutter-python-cli-app
 -   Documentation with [Sphinx](https://www.sphinx-doc.org/en/master/), [MyST](https://myst-parser.readthedocs.io/en/latest/), and [Read the Docs](https://readthedocs.org/) using the [Furo](https://pradyunsg.me/furo/) theme
 -   Automated release builds and uploads to [PyPI](https://pypi.org/)
 
-This template supports Python 3.8, 3.9, 3.10, 3.11 and 3.12.
+This template supports Python 3.9, 3.10, 3.11, 3.12 and 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ ignore = [
     "S607",  # start-process-with-partial-path
 ]
 src = ["hooks"]
-target-version = "py38"  # the minimum Python version supported, used by pyupgrade
+target-version = "py39"  # the minimum Python version supported, used by pyupgrade

--- a/{{ cookiecutter.app_name }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.app_name }}/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
 
       - name: Publish to PyPI

--- a/{{ cookiecutter.app_name }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.app_name }}/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Checkout the repo

--- a/{{ cookiecutter.app_name }}/.readthedocs.yaml
+++ b/{{ cookiecutter.app_name }}/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 sphinx:
   configuration: docs/conf.py

--- a/{{ cookiecutter.app_name }}/noxfile.py
+++ b/{{ cookiecutter.app_name }}/noxfile.py
@@ -15,11 +15,11 @@ ALL_PYTHON_VERSIONS = [
     #     if (match := re.search(r"Programming Language :: Python :: (?P<version>3\.\d+)", line)) is not None:
     #         cog.outl(f'"{match.group("version")}",')
     # ]]]
-    "3.8",
     "3.9",
     "3.10",
     "3.11",
     "3.12",
+    "3.13",
     # [[[end]]]
 ]
 
@@ -28,7 +28,7 @@ ALL_PYTHON_VERSIONS = [
 # rtd = yaml.safe_load(open(".readthedocs.yaml"))
 # cog.outl(f'DOCS_PYTHON_VERSION = "{rtd["build"]["tools"]["python"]}"')
 # ]]]
-DOCS_PYTHON_VERSION = "3.12"
+DOCS_PYTHON_VERSION = "3.13"
 # [[[end]]]
 
 ROOT_DIR = Path(__file__).resolve().parent

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -29,15 +29,15 @@ classifiers = [
     {% endif -%}
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Typing :: Typed",
 ]
-requires-python = "~=3.8"
+requires-python = "~=3.9"
 dependencies = [
     "click",
 {%- if cookiecutter.use_rich %}
@@ -91,7 +91,7 @@ lint.ignore = [
     "INP",  # flake8-no-pep420
 ]
 src = ["src", "tests", "docs"]
-target-version = "py38"  # the minimum Python version supported, used by pyupgrade
+target-version = "py39"  # the minimum Python version supported, used by pyupgrade
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = [

--- a/{{ cookiecutter.app_name }}/tests/utils.py
+++ b/{{ cookiecutter.app_name }}/tests/utils.py
@@ -1,9 +1,9 @@
 """Utility functions for testing {{ cookiecutter.app_name }}."""
 
-import subprocess
+from collections.abc import Sequence
 from dataclasses import dataclass
 from os import PathLike
-from typing import Any, Sequence, Union
+from typing import Any, Union
 
 # copied from `typeshed`
 StrOrBytesPath = Union[str, bytes, PathLike]


### PR DESCRIPTION
Closes #6 and #7.